### PR TITLE
Tweaks and fixes

### DIFF
--- a/Candy+CoreDataClass.swift
+++ b/Candy+CoreDataClass.swift
@@ -12,6 +12,10 @@ import CoreData
 @objc(Candy)
 public class Candy: NSManagedObject {
     public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        // NOTE: we do not want to generate a new UUID if DittoCoreData is
+        // inserting an instance, because it already has one.
+        guard self.dcdMirror?.isUpdatingCoreData == false else { return }
         self.id = UUID()
     }
 }

--- a/Country+CoreDataClass.swift
+++ b/Country+CoreDataClass.swift
@@ -12,6 +12,10 @@ import CoreData
 @objc(Country)
 public class Country: NSManagedObject {
     public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        // NOTE: we do not want to generate a new UUID if DittoCoreData is
+        // inserting an instance, because it already has one.
+        guard self.dcdMirror?.isUpdatingCoreData == false else { return }
         self.id = UUID()
     }
 }

--- a/DittoCoreDataExample/ContentView.swift
+++ b/DittoCoreDataExample/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
                         Section(country.wrappedFullName) {
                             ForEach(country.candyArray, id: \.self) { candy in
                                 Text(candy.wrappedName)
-                                Text(DateFormatter().string(from: candy.date!))
+                                Text(DateFormatter().string(from: candy.date ?? Date(timeIntervalSince1970: 0)))
                             }
                         }
                     }

--- a/DittoCoreDataExample/DittoCoreDataExample.xcdatamodeld/DittoCoreDataExample.xcdatamodel/contents
+++ b/DittoCoreDataExample/DittoCoreDataExample.xcdatamodeld/DittoCoreDataExample.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Candy" representedClassName="Candy" syncable="YES">
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO" preserveAfterDeletion="YES"/>
@@ -11,10 +11,5 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO" preserveAfterDeletion="YES"/>
         <attribute name="shortName" optional="YES" attributeType="String"/>
         <relationship name="candy" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Candy" inverseName="orgin" inverseEntity="Candy"/>
-        <uniquenessConstraints>
-            <uniquenessConstraint>
-                <constraint value="shortName"/>
-            </uniquenessConstraint>
-        </uniquenessConstraints>
     </entity>
 </model>

--- a/DittoCoreDataExample/Persistence.swift
+++ b/DittoCoreDataExample/Persistence.swift
@@ -77,10 +77,9 @@ class PersistenceController: NSObject {
         // MARK: Set up the Ditto instance:
 
         let identity = DittoIdentity.offlinePlayground(appID: "2f5619b5-7660-46df-ae10-189b80cf184e")
-        ditto = Ditto(identity: identity, persistenceDirectory: dittoDBURL)
-        ditto.isHistoryTrackingEnabled = true
+        ditto = Ditto(identity: identity, historyTrackingEnabled: true, persistenceDirectory: dittoDBURL)
 
-        try! ditto.setLicenseToken("o2d1c2VyX2lkcXdhbGtlckBkaXR0by5saXZlZmV4cGlyeXgYMjAyMy0wMi0yMlQyMDoyODo1OS4xODRaaXNpZ25hdHVyZXhYR0hjNzJCY2ozMHR5cEVKL3lRNGd5VFlUZ2xZSGw3cVFwTzdGeVdWUlNsZWNzb0JlRlhKTjlHUW05RnYrYkNWQUNrUmtrUzIrZXBQZllPbGJ0bW5XeVE9PQ==")
+        try! ditto.setOfflineOnlyLicenseToken("o2d1c2VyX2lkcXdhbGtlckBkaXR0by5saXZlZmV4cGlyeXgYMjAyMy0wMi0yMlQyMDoyODo1OS4xODRaaXNpZ25hdHVyZXhYR0hjNzJCY2ozMHR5cEVKL3lRNGd5VFlUZ2xZSGw3cVFwTzdGeVdWUlNsZWNzb0JlRlhKTjlHUW05RnYrYkNWQUNrUmtrUzIrZXBQZllPbGJ0bW5XeVE9PQ==")
         // MARK: Set up the DittoCoreData mirror:
 
         mirror = DCDMirror(ditto: ditto, managedObjectContext: container.viewContext, bindings: [
@@ -105,8 +104,8 @@ class PersistenceController: NSObject {
 
         var transportConfig = DittoTransportConfig()
         transportConfig.enableAllPeerToPeer()
-        ditto.setTransportConfig(config: transportConfig)
-        try! ditto.tryStartSync()
+        ditto.transportConfig = transportConfig
+        try! ditto.startSync()
     }
 }
 

--- a/DittoCoreDataExample/Persistence.swift
+++ b/DittoCoreDataExample/Persistence.swift
@@ -55,7 +55,7 @@ class PersistenceController: NSObject {
         persistentStoreDescription.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
         persistentStoreDescription.url = inMemory ? URL(fileURLWithPath: "/dev/null") : coreDataDBURL
 
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container.loadPersistentStores { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
@@ -70,7 +70,7 @@ class PersistenceController: NSObject {
                 */
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-        })
+        }
         
         self.container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
 

--- a/DittoCoreDataExample/Persistence.swift
+++ b/DittoCoreDataExample/Persistence.swift
@@ -95,6 +95,7 @@ class PersistenceController: NSObject {
             // method of the corresponding entity. This is exactly what we did
             // for the Item entity, see Item.swift and the CoreData model.
             DCDBinding(entity: Country.entity(), idAttributeName: "id"),
+            DCDBinding(entity: Candy.entity(), idAttributeName: "id"),
         ])
 
         super.init()

--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'DittoCoreDataExample' do
-  pod 'DittoCoreData', '=1.0.15-experimental.ditto-core-data.1'
+  pod 'DittoCoreData', '=3.0.4-experimental.ditto-core-data.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - DittoCoreData (1.0.15-experimental.ditto-core-data.1):
-    - DittoObjC (= 1.0.15-experimental.ditto-core-data.1)
-    - DittoSwift (= 1.0.15-experimental.ditto-core-data.1)
-  - DittoObjC (1.0.15-experimental.ditto-core-data.1)
-  - DittoSwift (1.0.15-experimental.ditto-core-data.1):
-    - DittoObjC (= 1.0.15-experimental.ditto-core-data.1)
+  - DittoCoreData (3.0.4-experimental.ditto-core-data.1):
+    - DittoObjC (= 3.0.4-experimental.ditto-core-data.1)
+    - DittoSwift (= 3.0.4-experimental.ditto-core-data.1)
+  - DittoObjC (3.0.4-experimental.ditto-core-data.1)
+  - DittoSwift (3.0.4-experimental.ditto-core-data.1):
+    - DittoObjC (= 3.0.4-experimental.ditto-core-data.1)
 
 DEPENDENCIES:
-  - DittoCoreData (= 1.0.15-experimental.ditto-core-data.1)
+  - DittoCoreData (= 3.0.4-experimental.ditto-core-data.1)
 
 SPEC REPOS:
   trunk:
@@ -16,10 +16,10 @@ SPEC REPOS:
     - DittoSwift
 
 SPEC CHECKSUMS:
-  DittoCoreData: a8cce94f8e863f90d81591781babd0f1b92cdda8
-  DittoObjC: 41095d1e6ac88e68c3e79199306f44e1e6ffeca9
-  DittoSwift: 04a294d26b7e50f1f421313c1bc6a1f1a6cf8fa1
+  DittoCoreData: d3b288bd8386e7fa52866d31f2cab9d6d4b020cf
+  DittoObjC: 2c46691730fa64233e3797e44ca5e683c2aca27f
+  DittoSwift: 9dff3c54571f42e94ce94ac150c815d46b77b724
 
-PODFILE CHECKSUM: 4b843b366d9d25b7b1c516a443facdfd4260a3a7
+PODFILE CHECKSUM: 586d3e9cc1bd13d92836ab3fb9c5f36269cf8204
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Ugrades to Ditto `3.0.4-experimental.ditto-core-data.1` and removes the `shortName` constraint because those aren't supported by DittoCoreData (yet). Couple more tweaks and fixes, see individual commits for details.
